### PR TITLE
Group partners by city and affiliation on partners map

### DIFF
--- a/js/f_a.js
+++ b/js/f_a.js
@@ -1,65 +1,99 @@
 var map;
 var geocoder;
-var url = '';
+var url = "";
 var addr;
-var partners = [] ;
+var partners = [];
+var partnersGroupedByCity = [];
 
 function loadPartners() {
-  url = 'partners.txt';
+  url = "partners.txt";
   $.ajax({
     cache: false,
     async: true,
     dataType: "text",
     url: url,
     success: function(res) {
-      buildPartners(res) ;
-      buildTable('f_a_datatable');
+      buildPartners(res);
+      buildTable("f_a_datatable");
     },
     error: function(jqxhr, errorText) {
-      $('.msg').html('Sorry, not availble now. Please try after sometime.');
+      $(".msg").html("Sorry, not availble now. Please try after sometime.");
       return 0;
     }
   });
   return 0;
 }
 
-var legend = document.getElementById('dataTable');
-var div = document.createElement('div');
+var legend = document.getElementById("dataTable");
+var div = document.createElement("div");
 legend.appendChild(div);
 
-
-google.maps.event.addDomListener(window, 'load', loadPartners);
+google.maps.event.addDomListener(window, "load", loadPartners);
 
 // Build the partners golbal vaiable from tabbed text
-function buildPartners ( tabbed_text ) {
+function buildPartners(tabbed_text) {
   let rows = tabbed_text.split("\n"); // Text => rows
-  let header = rows.shift().split("\t") ; // Take first row and split into columns
+  let header = rows.shift().split("\t"); // Take first row and split into columns
 
   // Now parse the rows
-  partners = [] ;
-  $.each ( rows , function ( row_num , row ) {
-      row = row.split("\t") ;
-      if ( row.length != header.length ) return ; // Paranoia
-      let partner = { row_num } ;
-      $.each ( header , function ( col_num , col_header ) {
-          partner[col_header.toLowerCase()] = row[col_num] ;
-      } ) ;
-      partners.push ( partner ) ;
-  } ) ;
+  partners = [];
+  $.each(rows, function(row_num, row) {
+    row = row.split("\t");
+    if (row.length != header.length) return; // Paranoia
+    let partner = { row_num };
+    $.each(header, function(col_num, col_header) {
+      partner[col_header.toLowerCase()] = row[col_num];
+    });
+    partners.push(partner);
+  });
+
+  // Now group partners by their city (for the map)
+  partnersGroupedByCity = Object.values(
+    partners.reduce(function(acc, partner) {
+      // check if we've visited this city before
+      if (!acc[partner.city]) {
+        acc[partner.city] = {
+          affiliations: {},
+          country: partner.country,
+          city: partner.city,
+          latitude: partner.latitude,
+          longitude: partner.longitude
+        };
+      }
+
+      // check if we've visited this affiliation before
+      if (!acc[partner.city].affiliations[partner.affiliation]) {
+        acc[partner.city].affiliations[partner.affiliation] = [];
+      }
+
+      // add the partner's name
+      acc[partner.city].affiliations[partner.affiliation].push(partner.name);
+
+      return acc;
+    }, {})
+  );
 }
 
 // Build table content from partners
 function buildTable(ele) {
-
   let div = document.getElementById(ele);
-  let table_str = "<table class='table table-striped'><th>Contact</th><th>Institution</th><th>City</th><th>Country</th>"
+  let table_str =
+    "<table class='table table-striped'><th>Contact</th><th>Institution</th><th>City</th><th>Country</th>";
   // Reading data from a 2D array
   $.each(partners, function(i, partner) {
     //$.each(arr, function(j, map) {
-    table_str += "<tr><td>"+ partner.name +"</td><td>" + partner.affiliation + "</td><td>" + partner.city + "</td><td>" + partner.country + "</td></tr>";
+    table_str +=
+      "<tr><td>" +
+      partner.name +
+      "</td><td>" +
+      partner.affiliation +
+      "</td><td>" +
+      partner.city +
+      "</td><td>" +
+      partner.country +
+      "</td></tr>";
     //});
-  })
+  });
   table_str += "</table>";
   $(div).html(table_str);
 }
-

--- a/js/partnerMap.js
+++ b/js/partnerMap.js
@@ -68,7 +68,9 @@ function add_partners_to_map() {
       })
       .join("<br/><br/>");
     marker
-      .bindPopup("<i>" + city.city + "</i><br/>" + affiliationsHtml)
+      .bindPopup(
+        "<i>" + city.city + ", " + city.country + "</i><br/>" + affiliationsHtml
+      )
       .openPopup();
 
     marker.on({

--- a/js/partnerMap.js
+++ b/js/partnerMap.js
@@ -1,77 +1,95 @@
-var mymap = L.map('partnersMapid',
-{
-    center: [0,0],
-    zoom: 2
+var mymap = L.map("partnersMapid", {
+  center: [0, 0],
+  zoom: 2
 });
 
-L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/streets-v10/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiY2dwcy13Z3NhLWVkZ2UiLCJhIjoiY2owaWE4d2w0MDAwMTMybXk4cTN2eG5xYSJ9.l5ZaIOGl6IY_2i_fWfsRDA', {
-    attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+L.tileLayer(
+  "https://api.mapbox.com/styles/v1/mapbox/streets-v10/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiY2dwcy13Z3NhLWVkZ2UiLCJhIjoiY2owaWE4d2w0MDAwMTMybXk4cTN2eG5xYSJ9.l5ZaIOGl6IY_2i_fWfsRDA",
+  {
+    attribution:
+      'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
     maxZoom: 18,
-    accessToken: 'pk.eyJ1IjoiY2dwcy13Z3NhLWVkZ2UiLCJhIjoiY2owaWE4d2w0MDAwMTMybXk4cTN2eG5xYSJ9.l5ZaIOGl6IY_2i_fWfsRDA'
-}).addTo(mymap);
+    accessToken:
+      "pk.eyJ1IjoiY2dwcy13Z3NhLWVkZ2UiLCJhIjoiY2owaWE4d2w0MDAwMTMybXk4cTN2eG5xYSJ9.l5ZaIOGl6IY_2i_fWfsRDA"
+  }
+).addTo(mymap);
 
 //L.tileLayer('https://a.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(mymap);
 
 // locations with a microreact tree
 
 var myIcon = L.icon({
-    iconUrl: 'img/microreact-map-marker2.svg',
-    shadowUrl: 'https://unpkg.com/leaflet@1.3.1/dist/images/marker-shadow.png',
-    iconSize: [25, 40],
-    iconAnchor: [15, 36],
-    popupAnchor: [-2, -28],
-    shadowSize: [50, 30],
-    shadowAnchor: [20, 36]
+  iconUrl: "img/microreact-map-marker2.svg",
+  shadowUrl: "https://unpkg.com/leaflet@1.3.1/dist/images/marker-shadow.png",
+  iconSize: [25, 40],
+  iconAnchor: [15, 36],
+  popupAnchor: [-2, -28],
+  shadowSize: [50, 30],
+  shadowAnchor: [20, 36]
 });
 
 var myBlueIcon = L.icon({
-    iconUrl: 'img/microreact-map-marker-blue.svg',
-    shadowUrl: 'https://unpkg.com/leaflet@1.3.1/dist/images/marker-shadow.png',
-    iconSize: [25, 40],
-    iconAnchor: [15, 36],
-    popupAnchor: [-2, -28],
-    shadowSize: [50, 30],
-    shadowAnchor: [20, 36]
+  iconUrl: "img/microreact-map-marker-blue.svg",
+  shadowUrl: "https://unpkg.com/leaflet@1.3.1/dist/images/marker-shadow.png",
+  iconSize: [25, 40],
+  iconAnchor: [15, 36],
+  popupAnchor: [-2, -28],
+  shadowSize: [50, 30],
+  shadowAnchor: [20, 36]
 });
 
-let isClicked = false
+let isClicked = false;
 
-$(document).ready ( function () {
-    add_partners_to_map() ;
-})
+$(document).ready(function() {
+  add_partners_to_map();
+});
 
 function add_partners_to_map() {
+  // Wait for data to be loaded in f_a.js (this is ugly but without a better understanding of the site I don't want to touch anything else)
+  if (
+    typeof partnersGroupedByCity == "undefined" ||
+    partnersGroupedByCity.length == 0
+  ) {
+    setTimeout(add_partners_to_map, 100);
+    return;
+  }
 
-    // Wait for data to be loaded in f_a.js (this is ugly but without a better understanding of the site I don't want to touch anything else)
-    if ( typeof partners == 'undefined' || partners.length == 0 ) {
-        setTimeout ( add_partners_to_map , 100 ) ;
-        return ;
-    }
+  // Add partners to map (grouped by city)
+  $.each(partnersGroupedByCity, function(dummy, city) {
+    let marker = L.marker([city.latitude, city.longitude], {
+      icon: myBlueIcon
+    }).addTo(mymap);
 
-    // Add partners to map
-    $.each ( partners , function ( dummy , partner ) {
-        let marker =  L.marker([partner.latitude, partner.longitude], {icon: myBlueIcon}).addTo(mymap);
-        marker.bindPopup("<b>"+partner.affiliation+"</b><br>"+partner.city+", "+partner.country+"<br>"+partner.name).openPopup();
+    var affiliationsHtml = Object.entries(city.affiliations)
+      .map(function(pair) {
+        const affiliation = pair[0];
+        const people = pair[1];
+        return "<b>" + affiliation + "</b><br/>" + people.join(", ");
+      })
+      .join("<br/><br/>");
+    marker
+      .bindPopup("<i>" + city.city + "</i><br/>" + affiliationsHtml)
+      .openPopup();
 
-        marker.on({
-            mouseover: function() {
-                if(!isClicked) {
-                    this.openPopup()
-                }
-            },
-            click: function() {
-                isClicked = true
-                this.openPopup()
-            }
-        })
-    } ) ;
-
-    mymap.on ({
-        click: function() {
-            isClicked = false
-        },
-        popupclose: function () {
-            isClicked = false
+    marker.on({
+      mouseover: function() {
+        if (!isClicked) {
+          this.openPopup();
         }
-    })
+      },
+      click: function() {
+        isClicked = true;
+        this.openPopup();
+      }
+    });
+  });
+
+  mymap.on({
+    click: function() {
+      isClicked = false;
+    },
+    popupclose: function() {
+      isClicked = false;
+    }
+  });
 }


### PR DESCRIPTION
This PR updates the tooltips on the partners map, such that there is a marker per city (with people listed under their affiliations) rather than a marker per person.

After the change:
<img width="945" alt="Screenshot 2020-02-28 at 10 31 18" src="https://user-images.githubusercontent.com/60611740/75541283-8aefb600-5a15-11ea-86c4-bda45a977475.png">
